### PR TITLE
Script errors in resources anbd map code

### DIFF
--- a/community.html
+++ b/community.html
@@ -90,14 +90,6 @@
             verified members.
           </a>
         </li>
-        <li>
-          <a
-            class="server-card"
-            href="./contact.html"
-          >
-            <strong>PLACEHOLDER</strong> &mdash; placeholder
-          </a>
-        </li>
       </ul>
       <p>
         Server access is whitelist only to our verified community members. Contact a

--- a/donate.html
+++ b/donate.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>Donate</title>
+    <title>TMH | Donate</title>
     <link rel="stylesheet" href="./styles/site.css" />
 </head>
 <body class="page page--donate">
@@ -52,11 +52,7 @@
     </div>
 
     <p>
-        For more details about what your donations can do for TMH, you can check <br>
-        our full breakdown here. <!--Add a link when we have an official document certified !-->
-    </p>
-    <p>
-        Donations are processed temporarily Venmo. Fill out the form below and you'll be redirected
+        Donations are processed temporarily via Venmo. Fill out the form below and you'll be redirected
         to complete your contribution.
     </p>
 </main>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>It works!</title>
+    <title>The Military Hub</title>
     <link rel="stylesheet" href="./styles/site.css" />
     <script src="./scripts/bonzi.js" defer></script>
 </head>

--- a/resources.html
+++ b/resources.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>Resources</title>
+    <title>TMH | Resources</title>
     <link rel="stylesheet" href="./styles/vendor/leaflet.css" />
     <link rel="stylesheet" href="./styles/site.css" />
 </head>
@@ -48,8 +48,8 @@
         </div>
     </main>
 
-<section class="info-panel" id="resources-transition">
-        <h4 class="text-center">Transition Resources</h4>
+    <section class="info-panel" id="resources-transition">
+        <h2 class="text-center">Transition Resources</h2>
         <p>
             <a href="https://wpath.org/publications/soc8">WPATH</a><br>
             <a href="https://www.endocrine.org/advocacy/position-statements/transgender-health">Endocrine Society</a><br>
@@ -57,7 +57,7 @@
     </section>
 
     <section class="info-panel" id="resources-crisis">
-        <h4 class="text-center">Crisis Resources</h4>
+        <h2 class="text-center">Crisis Resources</h2>
         <p>
            <a href="https://988lifeline.org">Suicide Hotline</a> - Call or Text 988<br>
            <a href="https://translifeline.org">Trans Lifeline</a> - Call 877-565-8860<br>
@@ -66,7 +66,7 @@
     </section>
 
     <section class="info-panel" id="resources-history">
-        <h4 class="text-center">History of Transgender Service in the Armed Forces</h4>
+        <h2 class="text-center">History of Transgender Service in the Armed Forces</h2>
         <p>
             <br>
             <br>
@@ -75,7 +75,7 @@
     </section>
 
     <section class="info-panel" id="resources-advocacy">
-        <h4 class="text-center">Other Trans Advocacy Groups</h4>
+        <h2 class="text-center">Other Trans Advocacy Groups</h2>
         <p>
             <a href="https://spartapride.org">SPARTA Pride</a><br>
             <a href="https://transequality.org">Advocates for Trans Equality</a><br>
@@ -87,7 +87,7 @@
     </section>
 
     <section class="info-panel" id="resources-education">
-        <h4 class="text-center">Educational Resources</h4>
+        <h2 class="text-center">Educational Resources</h2>
         <p>
             <br>
             <br>
@@ -96,7 +96,7 @@
     </section>
 
     <section class="info-panel info-panel--map" id="state-resources">
-        <h4 class="text-center">State Resource Map</h4>
+        <h2 class="text-center">State Resource Map</h2>
         <p class="text-center">
             Hover over any state to highlight it in blue. Click a state then scroll down to the dropdown menu to view files.
         </p>

--- a/scripts/state-map.js
+++ b/scripts/state-map.js
@@ -62,13 +62,13 @@
     map.setMaxBounds(bounds.pad(0.2));
 
     if (useKmlAsBase) {
-      const baseOverlay = createOverlayLayer(baseProjection);
+      const baseOverlay = createOverlayLayer(baseProjection, viewBox.height);
       baseOverlay.addTo(map);
     } else {
-      const stateLayer = createStateLayer(baseProjection.geojson, panelApi, filesData);
+      const stateLayer = createStateLayer(baseProjection.geojson, panelApi, filesData, viewBox.height);
       stateLayer.addTo(map);
       if (overlayProjection) {
-        const overlayLayer = createOverlayLayer(overlayProjection);
+        const overlayLayer = createOverlayLayer(overlayProjection, viewBox.height);
         overlayLayer.addTo(map);
       }
     }
@@ -110,7 +110,7 @@
     }
   }
 
-  function createStateLayer(geojson, panelApi, filesData) {
+  function createStateLayer(geojson, panelApi, filesData, viewBoxHeight) {
     const defaultStyle = {
       className: 'us-map__state',
       color: 'rgba(255, 255, 255, 0.25)',
@@ -127,6 +127,7 @@
 
     let stateLayer = null;
     stateLayer = L.geoJSON(geojson, {
+      coordsToLatLng: (c) => L.latLng(viewBoxHeight - c[1], c[0]),
       style: defaultStyle,
       onEachFeature: (feature, layer) => {
         const name = feature && feature.properties ? feature.properties.name : 'State';
@@ -153,11 +154,12 @@
     return stateLayer;
   }
 
-  function createOverlayLayer(projection) {
+  function createOverlayLayer(projection, viewBoxHeight) {
     const group = L.layerGroup();
 
     if (projection.geojson && projection.geojson.features.length) {
       const overlayLayer = L.geoJSON(projection.geojson, {
+        coordsToLatLng: (c) => L.latLng(viewBoxHeight - c[1], c[0]),
         style: (feature) => {
           const type = feature.geometry ? feature.geometry.type : '';
           if (type === 'LineString' || type === 'MultiLineString') {
@@ -177,14 +179,22 @@
           };
         },
         pointToLayer: (feature, latlng) => buildOverlayMarker(feature, latlng),
-        interactive: false
+        onEachFeature: (feature, layer) => {
+          if (feature.geometry && feature.geometry.type === 'Point' && feature.properties && feature.properties.name) {
+            layer.bindTooltip(feature.properties.name, { sticky: true });
+          }
+        }
       });
       group.addLayer(overlayLayer);
     }
 
     if (projection.images && projection.images.length) {
       projection.images.forEach((image) => {
-        const overlay = L.imageOverlay(image.href, image.bounds, { interactive: false });
+        const flippedBounds = [
+          [viewBoxHeight - image.bounds[1][0], image.bounds[0][1]],
+          [viewBoxHeight - image.bounds[0][0], image.bounds[1][1]]
+        ];
+        const overlay = L.imageOverlay(image.href, flippedBounds, { interactive: false });
         group.addLayer(overlay);
       });
     }
@@ -203,7 +213,7 @@
         iconAnchor: [size / 2, size / 2],
         className: 'us-map__marker'
       });
-      return L.marker(latlng, { icon, interactive: false });
+      return L.marker(latlng, { icon });
     }
     return L.circleMarker(latlng, {
       radius: 5,
@@ -211,8 +221,7 @@
       fillColor: 'rgba(244, 180, 0, 0.65)',
       fillOpacity: 0.9,
       weight: 1,
-      className: 'us-map__marker',
-      interactive: false
+      className: 'us-map__marker'
     });
   }
 

--- a/shop.html
+++ b/shop.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>Shop</title>
+    <title>TMH | Merch Store</title>
     <link rel="stylesheet" href="./styles/site.css" />
 </head>
 <body class="page page--shop">


### PR DESCRIPTION
Fix upside-down map by flipping Y coordinates when converting projected screen-space coordinates to Leaflet's CRS.Simple space, which expects Y to increase upward Make KML resource markers interactive, they were previously hardcoded as non-interactive; hovering a marker now shows a tooltip with the location name Fix image overlay bounds to use the same Y-flip correction

Resources (resources.html)

Switch map mode from "replace" to "overlay" so state boundaries load from GeoJSON and KML markers render on top Correct section heading levels from h4 to h2 throughout Update page title to "TMH | Resources"